### PR TITLE
Remove option to enable/disable promotional widgets

### DIFF
--- a/dist/resources/js/StateController.js
+++ b/dist/resources/js/StateController.js
@@ -220,7 +220,7 @@ SequraFE.appPages = {
                 if (
                     dataStore.connectionSettings?.connectionData?.every(c => c.username && c.password) &&
                     dataStore.countrySettings?.length &&
-                    dataStore.widgetSettings?.useWidgets !== undefined &&
+                    dataStore.widgetSettings?.widgetStyles !== undefined &&
                     !SequraFE.state.getCredentialsChanged()
                 ) {
                     currentState.split('-')[0] === SequraFE.appStates.ONBOARDING ?
@@ -278,7 +278,7 @@ SequraFE.appPages = {
             if (
                 !dataStore.connectionSettings?.connectionData?.every(c => c.username && c.password) ||
                 dataStore.countrySettings?.length === 0 ||
-                dataStore.widgetSettings?.useWidgets === undefined ||
+                dataStore.widgetSettings?.widgetStyles === undefined ||
                 SequraFE.state.getCredentialsChanged()
             ) {
                 this.goToState(SequraFE.appStates.ONBOARDING, additionalConfig, true);

--- a/dist/resources/js/WidgetSettingsForm.js
+++ b/dist/resources/js/WidgetSettingsForm.js
@@ -25,7 +25,6 @@ if (!window.SequraFE) {
 
     /**
      * @typedef WidgetSettings
-     * @property {boolean} useWidgets
      * @property {boolean} displayWidgetOnProductPage
      * @property {boolean} showInstallmentAmountInProductListing
      * @property {boolean} showInstallmentAmountInCartPage
@@ -98,7 +97,6 @@ if (!window.SequraFE) {
 
         /** @type WidgetSettings */
         const defaultFormData = {
-            useWidgets: false,
             displayWidgetOnProductPage: false,
             widgetStyles: '{"alignment":"center","amount-font-bold":"true","amount-font-color":"#1C1C1C","amount-font-size":"15","background-color":"white","border-color":"#B1AEBA","border-radius":"","class":"","font-color":"#1C1C1C","link-font-color":"#1C1C1C","link-underline":"true","no-costs-claim":"","size":"M","starting-text":"only","type":"banner"}',
             showInstallmentAmountInProductListing: false,
@@ -147,15 +145,6 @@ if (!window.SequraFE) {
                         title: `widgets.title.${configuration.appState}`,
                         text: 'widgets.description'
                     }),
-                    generator.createRadioGroupField({
-                        value: changedSettings.useWidgets,
-                        label: 'widgets.usePromotionalComponents.label',
-                        options: [
-                            { label: 'widgets.usePromotionalComponents.options.yes', value: true },
-                            { label: 'widgets.usePromotionalComponents.options.no', value: false }
-                        ],
-                        onChange: (value) => handleChange('useWidgets', value)
-                    })
                 ])
             );
 
@@ -170,10 +159,6 @@ if (!window.SequraFE) {
          * Renders additional widget settings.
          */
         const renderAdditionalSettings = () => {
-            if (!changedSettings.useWidgets) {
-                return;
-            }
-
             const pageInnerContent = document.querySelector('.sq-content-inner');
 
             pageInnerContent?.append(
@@ -338,9 +323,6 @@ if (!window.SequraFE) {
          * @returns {boolean} Returns true if all changedSettings values are valid, false otherwise.
          */
         const validate = () => {
-            if (!changedSettings.useWidgets) {
-                return true;
-            }
             let isValid = validator.validateJSON(
                 document.querySelector(`[name="widget-configurator-input"]`),
                 true,
@@ -512,9 +494,7 @@ if (!window.SequraFE) {
         const handleChange = (name, value) => {
             changedSettings[name] = value;
 
-            if (name === 'useWidgets' || name === 'showInstallmentAmountInProductListing') {
-                refreshForm();
-            } else if (name === 'displayWidgetOnProductPage') {
+            if (name === 'displayWidgetOnProductPage') {
                 showOrHideRelatedFields('.sq-product-related-field', value);
             } else if (name === 'showInstallmentAmountInCartPage') {
                 showOrHideRelatedFields('.sq-cart-related-field', value);

--- a/dist/resources/lang/en.json
+++ b/dist/resources/lang/en.json
@@ -218,13 +218,6 @@
       "settings": "Promotional widgets settings"
     },
     "description": "Promotional components allows you to display promotional widgets and educational pop-ups that shows and explains which SeQura products the shopper offers and how they work, which will help the shop increase average order value and conversion rates.",
-    "usePromotionalComponents": {
-      "label": "Would you like to use promotional components?",
-      "options": {
-        "yes": "Yes",
-        "no": "No, thanks"
-      }
-    },
     "displayOnProductPage": {
       "label": "Display widget on product page",
       "description": "Specify whether payment method icon should be displayed to customers on the checkout."

--- a/dist/resources/lang/es.json
+++ b/dist/resources/lang/es.json
@@ -217,13 +217,6 @@
       "settings": "Configuración de widgets promocionales"
     },
     "description": "Etiquetas de widgets",
-    "usePromotionalComponents": {
-      "label": "¿Te gustaría utilizar componentes promocionales?",
-      "options": {
-        "yes": "Sí",
-        "no": "No, gracias"
-      }
-    },
     "displayOnProductPage": {
       "label": "Mostrar widget en la página de productos",
       "description": "Especificar si el icono del método de pago debe mostrarse a los clientes en la página de pago."

--- a/dist/resources/lang/fr.json
+++ b/dist/resources/lang/fr.json
@@ -218,13 +218,6 @@
       "settings": "Paramètres des widgets promotionnels"
     },
     "description": "Les composants promotionnels permettent d'afficher des widgets promotionnels et des pop-ups éducatifs qui montrent et expliquent quels produits SeQura le client propose et comment ils fonctionnent, ce qui aidera la boutique à augmenter la valeur moyenne des commandes et les taux de conversion.",
-    "usePromotionalComponents": {
-      "label": "Souhaitez-vous utiliser des composants promotionnels ?",
-      "options": {
-        "yes": "Oui",
-        "no": "Non, merci"
-      }
-    },
     "displayOnProductPage": {
       "label": "Afficher le widget sur la page produit",
       "description": "Indiquez si l'icône du mode de paiement doit être affichée aux clients lors du paiement."

--- a/dist/resources/lang/it.json
+++ b/dist/resources/lang/it.json
@@ -218,13 +218,6 @@
       "settings": "Impostazioni widget promozionali"
     },
     "description": "I componenti promozionali ti permettono di mostrare widget promozionali e popup educativi che mostrano e spiegano quali prodotti SeQura offre il cliente e come funzionano, aiutando il negozio ad aumentare il valore medio degli ordini e i tassi di conversione.",
-    "usePromotionalComponents": {
-      "label": "Vorresti utilizzare componenti promozionali?",
-      "options": {
-        "yes": "Sì",
-        "no": "No, grazie"
-      }
-    },
     "displayOnProductPage": {
       "label": "Mostra widget sulla pagina prodotto",
       "description": "Specifica se l'icona del metodo di pagamento deve essere mostrata ai clienti durante il checkout."

--- a/dist/resources/lang/pt.json
+++ b/dist/resources/lang/pt.json
@@ -219,13 +219,6 @@
       "settings": "Definições de widgets promocionais"
     },
     "description": "Os componentes promocionais permitem exibir widgets promocionais e pop-ups educativos que mostram e explicam quais produtos SeQura o lojista oferece e como funcionam, o que ajudará a loja a aumentar o valor médio do pedido e as taxas de conversão.",
-    "usePromotionalComponents": {
-      "label": "Gostaria de usar componentes promocionais?",
-      "options": {
-        "yes": "Sim",
-        "no": "Não, obrigado"
-      }
-    },
     "displayOnProductPage": {
       "label": "Exibir widget na página do produto",
       "description": "Especifique se o ícone do método de pagamento deve ser exibido aos clientes no checkout."

--- a/src/controllers/StateController.js
+++ b/src/controllers/StateController.js
@@ -220,7 +220,7 @@ SequraFE.appPages = {
                 if (
                     dataStore.connectionSettings?.connectionData?.every(c => c.username && c.password) &&
                     dataStore.countrySettings?.length &&
-                    dataStore.widgetSettings?.useWidgets !== undefined &&
+                    dataStore.widgetSettings?.widgetStyles !== undefined &&
                     !SequraFE.state.getCredentialsChanged()
                 ) {
                     currentState.split('-')[0] === SequraFE.appStates.ONBOARDING ?
@@ -278,7 +278,7 @@ SequraFE.appPages = {
             if (
                 !dataStore.connectionSettings?.connectionData?.every(c => c.username && c.password) ||
                 dataStore.countrySettings?.length === 0 ||
-                dataStore.widgetSettings?.useWidgets === undefined ||
+                dataStore.widgetSettings?.widgetStyles === undefined ||
                 SequraFE.state.getCredentialsChanged()
             ) {
                 this.goToState(SequraFE.appStates.ONBOARDING, additionalConfig, true);

--- a/src/forms/WidgetSettingsForm.js
+++ b/src/forms/WidgetSettingsForm.js
@@ -25,7 +25,6 @@ if (!window.SequraFE) {
 
     /**
      * @typedef WidgetSettings
-     * @property {boolean} useWidgets
      * @property {boolean} displayWidgetOnProductPage
      * @property {boolean} showInstallmentAmountInProductListing
      * @property {boolean} showInstallmentAmountInCartPage
@@ -98,7 +97,6 @@ if (!window.SequraFE) {
 
         /** @type WidgetSettings */
         const defaultFormData = {
-            useWidgets: false,
             displayWidgetOnProductPage: false,
             widgetStyles: '{"alignment":"center","amount-font-bold":"true","amount-font-color":"#1C1C1C","amount-font-size":"15","background-color":"white","border-color":"#B1AEBA","border-radius":"","class":"","font-color":"#1C1C1C","link-font-color":"#1C1C1C","link-underline":"true","no-costs-claim":"","size":"M","starting-text":"only","type":"banner"}',
             showInstallmentAmountInProductListing: false,
@@ -147,15 +145,6 @@ if (!window.SequraFE) {
                         title: `widgets.title.${configuration.appState}`,
                         text: 'widgets.description'
                     }),
-                    generator.createRadioGroupField({
-                        value: changedSettings.useWidgets,
-                        label: 'widgets.usePromotionalComponents.label',
-                        options: [
-                            { label: 'widgets.usePromotionalComponents.options.yes', value: true },
-                            { label: 'widgets.usePromotionalComponents.options.no', value: false }
-                        ],
-                        onChange: (value) => handleChange('useWidgets', value)
-                    })
                 ])
             );
 
@@ -170,10 +159,6 @@ if (!window.SequraFE) {
          * Renders additional widget settings.
          */
         const renderAdditionalSettings = () => {
-            if (!changedSettings.useWidgets) {
-                return;
-            }
-
             const pageInnerContent = document.querySelector('.sq-content-inner');
 
             pageInnerContent?.append(
@@ -338,9 +323,6 @@ if (!window.SequraFE) {
          * @returns {boolean} Returns true if all changedSettings values are valid, false otherwise.
          */
         const validate = () => {
-            if (!changedSettings.useWidgets) {
-                return true;
-            }
             let isValid = validator.validateJSON(
                 document.querySelector(`[name="widget-configurator-input"]`),
                 true,
@@ -512,9 +494,7 @@ if (!window.SequraFE) {
         const handleChange = (name, value) => {
             changedSettings[name] = value;
 
-            if (name === 'useWidgets' || name === 'showInstallmentAmountInProductListing') {
-                refreshForm();
-            } else if (name === 'displayWidgetOnProductPage') {
+            if (name === 'displayWidgetOnProductPage') {
                 showOrHideRelatedFields('.sq-product-related-field', value);
             } else if (name === 'showInstallmentAmountInCartPage') {
                 showOrHideRelatedFields('.sq-cart-related-field', value);

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -218,13 +218,6 @@
       "settings": "Promotional widgets settings"
     },
     "description": "Promotional components allows you to display promotional widgets and educational pop-ups that shows and explains which SeQura products the shopper offers and how they work, which will help the shop increase average order value and conversion rates.",
-    "usePromotionalComponents": {
-      "label": "Would you like to use promotional components?",
-      "options": {
-        "yes": "Yes",
-        "no": "No, thanks"
-      }
-    },
     "displayOnProductPage": {
       "label": "Display widget on product page",
       "description": "Specify whether payment method icon should be displayed to customers on the checkout."

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -217,13 +217,6 @@
       "settings": "Configuración de widgets promocionales"
     },
     "description": "Etiquetas de widgets",
-    "usePromotionalComponents": {
-      "label": "¿Te gustaría utilizar componentes promocionales?",
-      "options": {
-        "yes": "Sí",
-        "no": "No, gracias"
-      }
-    },
     "displayOnProductPage": {
       "label": "Mostrar widget en la página de productos",
       "description": "Especificar si el icono del método de pago debe mostrarse a los clientes en la página de pago."

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -218,13 +218,6 @@
       "settings": "Paramètres des widgets promotionnels"
     },
     "description": "Les composants promotionnels permettent d'afficher des widgets promotionnels et des pop-ups éducatifs qui montrent et expliquent quels produits SeQura le client propose et comment ils fonctionnent, ce qui aidera la boutique à augmenter la valeur moyenne des commandes et les taux de conversion.",
-    "usePromotionalComponents": {
-      "label": "Souhaitez-vous utiliser des composants promotionnels ?",
-      "options": {
-        "yes": "Oui",
-        "no": "Non, merci"
-      }
-    },
     "displayOnProductPage": {
       "label": "Afficher le widget sur la page produit",
       "description": "Indiquez si l'icône du mode de paiement doit être affichée aux clients lors du paiement."

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -218,13 +218,6 @@
       "settings": "Impostazioni widget promozionali"
     },
     "description": "I componenti promozionali ti permettono di mostrare widget promozionali e popup educativi che mostrano e spiegano quali prodotti SeQura offre il cliente e come funzionano, aiutando il negozio ad aumentare il valore medio degli ordini e i tassi di conversione.",
-    "usePromotionalComponents": {
-      "label": "Vorresti utilizzare componenti promozionali?",
-      "options": {
-        "yes": "Sì",
-        "no": "No, grazie"
-      }
-    },
     "displayOnProductPage": {
       "label": "Mostra widget sulla pagina prodotto",
       "description": "Specifica se l'icona del metodo di pagamento deve essere mostrata ai clienti durante il checkout."

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -219,13 +219,6 @@
       "settings": "Definições de widgets promocionais"
     },
     "description": "Os componentes promocionais permitem exibir widgets promocionais e pop-ups educativos que mostram e explicam quais produtos SeQura o lojista oferece e como funcionam, o que ajudará a loja a aumentar o valor médio do pedido e as taxas de conversão.",
-    "usePromotionalComponents": {
-      "label": "Gostaria de usar componentes promocionais?",
-      "options": {
-        "yes": "Sim",
-        "no": "Não, obrigado"
-      }
-    },
     "displayOnProductPage": {
       "label": "Exibir widget na página do produto",
       "description": "Especifique se o ícone do método de pagamento deve ser exibido aos clientes no checkout."


### PR DESCRIPTION
 ### What is the goal?

- Remove “Would you like to use promotional widgets?” option from Widget Settings Admin UI.

### References
* **Issue:** [LIS-94](https://sequra.atlassian.net/browse/LIS-94)
 
### How is it being implemented?
- Removed option to enable/disable promotional widgets on WidgetSettingsForm
- Removed useWidgets flag for determining the current UI state
- Removed translations connected to this option

### How is it tested?
- Manual tests
   - Follow the README instructions for building the resources
   - Follow the README instructions for copying resources into the Magento 2 integration
   - Install the SeQura module in the Magento 2
   - Connect the integration
   - Perform different configuration scenarios


[LIS-94]: https://sequra.atlassian.net/browse/LIS-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ