### PR TITLE
Add button for webhook re-registration on the Connection page

### DIFF
--- a/dist/resources/css/sequra-core.css
+++ b/dist/resources/css/sequra-core.css
@@ -1381,6 +1381,10 @@
 #sequra-page .sq-field-wrapper.sqm--block.sqm--bellow-frame {
   margin-top: 30px;
 }
+#sequra-page .sq-field-wrapper.sqm--block.sqm--bellow-frame .sqm--actions-bar {
+  display: flex;
+  gap: 6px;
+}
 #sequra-page .sq-field-wrapper .items {
   display: flex;
   align-items: center;

--- a/dist/resources/js/AdvancedController.js
+++ b/dist/resources/js/AdvancedController.js
@@ -303,7 +303,7 @@ if (!window.SequraFE) {
 
             const resetDetails = () => {
                 document.querySelectorAll('.sqm--log-context').forEach(elem => {
-                    elem.style.display = 'none'
+                    elem.style.display = 'none';
                     elem.innerHTML = '';
                 });
                 document.querySelectorAll('.sqm--log-details').forEach(elem => {

--- a/dist/resources/js/ConnectionSettingsForm.js
+++ b/dist/resources/js/ConnectionSettingsForm.js
@@ -29,6 +29,7 @@ if (!window.SequraFE) {
      * connectUrl: string,
      * validateConnectionDataUrl: string,
      * disconnectUrl: string,
+     * reRegisterUrl: string,
      * page: string,
      * appState: string
      * }} configuration
@@ -316,15 +317,31 @@ if (!window.SequraFE) {
                 return;
             }
 
-            pageInnerContent?.append(
-                generator.createButtonField({
-                    className: 'sqm--block sqm--bellow-frame',
-                    buttonType: 'danger',
-                    buttonSize: 'medium',
-                    buttonLabel: 'general.disconnect',
-                    onClick: handleDisconnect
-                })
-            );
+            const reRegisterWebhooksButton = generator.createButton({
+                type: 'secondary',
+                size: 'medium',
+                className: '',
+                onClick: handleReRegister,
+                label: 'Re-register webhooks'
+            })
+
+            const disconnectionButton = generator.createButton({
+                type: 'danger',
+                size: 'medium',
+                className: '',
+                onClick: handleDisconnect,
+                label: 'general.disconnect'
+            })
+
+            const actionsBar = generator.createActionsBar(
+                'sqm--block sqm--bellow-frame',
+                [
+                    reRegisterWebhooksButton,
+                    disconnectionButton
+                ]
+            )
+
+            pageInnerContent?.append(actionsBar);
 
             pageContent?.append(
                 generator.createPageFooter({
@@ -555,7 +572,7 @@ if (!window.SequraFE) {
 
                 utilities.showLoader();
 
-                api.post(configuration.disconnectUrl, createPayload(), SequraFE.customHeader)
+                api.post(configuration.disconnectUrl, createDisconnectionPayload(), SequraFE.customHeader)
                     .then(() => SequraFE.state.display())
                     .finally(utilities.hideLoader);
             })
@@ -564,7 +581,37 @@ if (!window.SequraFE) {
         /**
          * Handles the disconnect button click.
          */
-        const createPayload = () => {
+        const handleReRegister = () => {
+            utilities.showLoader();
+
+            api.post(configuration.reRegisterUrl, createReRegisterPayload(), SequraFE.customHeader)
+                .then((response) => {
+                    if (response.isSuccessful) {
+                        SequraFE.responseService.successHandler(
+                            {successMessage: 'connection.webhookReRegistration.successMessage'}
+                        ).catch(() => {
+                        });
+                    } else {
+                        SequraFE.responseService.errorHandler(
+                            {errorMessage: 'connection.webhookReRegistration.errorMessage'}
+                        ).catch(() => {
+                        });
+                    }
+
+                })
+                .catch((error) => {
+                    SequraFE.responseService.errorHandler(
+                        {errorMessage: error}
+                    ).catch(() => {
+                    });
+                })
+                .finally(utilities.hideLoader);
+        }
+
+        /**
+         * Creates connection payload.
+         */
+        const createDisconnectionPayload = () => {
             const isFullDisconnect = activeDeployments.length <= 1;
             const deploymentId = activeDeploymentId;
 
@@ -574,6 +621,22 @@ if (!window.SequraFE) {
             };
         }
 
+        /**
+         * Creates payload for webhook re-registration.
+         */
+        const createReRegisterPayload = () => {
+            const environment = changedSettings.environment ?? 'sandbox';
+            const username = getSettingsForActiveDeployment(changedSettings).username ?? '';
+            const password = getSettingsForActiveDeployment(changedSettings).password ?? '';
+            const deployment = getSettingsForActiveDeployment(changedSettings).deployment ?? '';
+
+            return {
+                environment,
+                username,
+                password,
+                deployment
+            };
+        }
 
         /**
          * Disables the form footer controls.

--- a/dist/resources/js/ConnectionSettingsForm.js
+++ b/dist/resources/js/ConnectionSettingsForm.js
@@ -589,8 +589,7 @@ if (!window.SequraFE) {
                     if (response.isSuccessful) {
                         SequraFE.responseService.successHandler(
                             {successMessage: 'connection.webhookReRegistration.successMessage'}
-                        ).catch(() => {
-                        });
+                        )
                     } else {
                         SequraFE.responseService.errorHandler(
                             {errorMessage: 'connection.webhookReRegistration.errorMessage'}
@@ -600,8 +599,9 @@ if (!window.SequraFE) {
 
                 })
                 .catch((error) => {
+                    const errorMessage = String(error && error.message ? error.message : error);
                     SequraFE.responseService.errorHandler(
-                        {errorMessage: error}
+                        {errorMessage: errorMessage}
                     ).catch(() => {
                     });
                 })

--- a/dist/resources/js/ElementGenerator.js
+++ b/dist/resources/js/ElementGenerator.js
@@ -438,6 +438,20 @@ if (!window.SequraFE) {
         return createFieldWrapper(buttonLink, label, description, '', error, '');
     };
 
+
+    /**
+     * Adds bar with multiple action buttons.
+     *
+     * @returns HTMLElement
+     */
+    const createActionsBar = (className, children) => {
+        const fieldWrapper = createElement('div', 'sq-field-wrapper ' + className)
+        const inputWrapper = createElement('div', 'sqm--actions-bar', '', null, children);
+        fieldWrapper.append(inputWrapper);
+
+        return fieldWrapper;
+    };
+
     /**
      * Creates multi item selector wrapper around the provided multi item selector element.
      *
@@ -691,6 +705,7 @@ if (!window.SequraFE) {
         createButtonField,
         createButtonLink,
         createButtonLinkField,
+        createActionsBar,
         createMultiItemSelectorField,
         createCountryField,
         createFormFields,

--- a/dist/resources/js/ElementGenerator.js
+++ b/dist/resources/js/ElementGenerator.js
@@ -685,7 +685,7 @@ if (!window.SequraFE) {
                 )
             ]
         );
-    }
+    };
 
     SequraFE.elementGenerator = {
         createElement,

--- a/dist/resources/js/GeneralSettingsForm.js
+++ b/dist/resources/js/GeneralSettingsForm.js
@@ -430,7 +430,7 @@ if (!window.SequraFE) {
             }
 
             // Update the visibility of the fields.
-            const selector = '.sq-field-wrapper:has(.sq-service-related-field), .sq-field-wrapper.sq-service-related-field'
+            const selector = '.sq-field-wrapper:has(.sq-service-related-field), .sq-field-wrapper.sq-service-related-field';
             const hiddenClass = 'sqs--hidden';
             document.querySelectorAll(selector).forEach((el) => {
                 if (changedGeneralSettings.enabledForServices.length > 0) {

--- a/dist/resources/js/GeneralSettingsForm.js
+++ b/dist/resources/js/GeneralSettingsForm.js
@@ -397,7 +397,7 @@ if (!window.SequraFE) {
                     }
                 }
                 return countriesString ? translate('countries.enabledCountries').replace('{countries}', countriesString) : '';
-            }
+            };
             const descriptionWithCountries = (description, countries) => SequraFE.translationService.translate(description) + countriesString(countries);
 
             const enabledForServiceInput = document.querySelector(`.${classNameEnabledForService} input`);

--- a/dist/resources/js/OnboardingController.js
+++ b/dist/resources/js/OnboardingController.js
@@ -145,10 +145,9 @@ if (!window.SequraFE) {
         /**
          * Renders the widgets settings form.
          *
-         * @param paymentMethods
          * @param allAvailablePaymentMethods
          */
-        const renderWidgetSettingsForm = (paymentMethods, allAvailablePaymentMethods) => {
+        const renderWidgetSettingsForm = (allAvailablePaymentMethods) => {
             if (!SequraFE.state.getData('allAvailablePaymentMethods')) {
                 SequraFE.state.setData('allAvailablePaymentMethods', allAvailablePaymentMethods)
             }

--- a/dist/resources/js/ResponseService.js
+++ b/dist/resources/js/ResponseService.js
@@ -37,6 +37,29 @@ if (!window.SequraFE) {
         };
 
         /**
+         * Handles a success response from the submit action.
+         *
+         * @param {{successMessage?: string}} response
+         * @returns {Promise<void>}
+         */
+        this.successHandler = (response) => {
+            const {utilities, templateService, elementGenerator} = SequraFE;
+            let container = document.querySelector('.sqp-flash-message-wrapper');
+            if (!container) {
+                container = elementGenerator.createElement('div', 'sqp-flash-message-wrapper');
+                templateService.getMainPage().prepend(container);
+            }
+
+            templateService.clearComponent(container);
+
+            if (response.successMessage) {
+                container.prepend(utilities.createFlashMessage(response.successMessage, 'success'));
+            }
+
+            return Promise.reject(response);
+        };
+
+        /**
          * Handles unauthorized response.
          *
          * @param {{errorMessage?: string, errorCode?: string, statusCode?: number}} response

--- a/dist/resources/js/ResponseService.js
+++ b/dist/resources/js/ResponseService.js
@@ -40,7 +40,7 @@ if (!window.SequraFE) {
          * Handles a success response from the submit action.
          *
          * @param {{successMessage?: string}} response
-         * @returns {Promise<void>}
+         * @returns {void}
          */
         this.successHandler = (response) => {
             const {utilities, templateService, elementGenerator} = SequraFE;
@@ -55,8 +55,6 @@ if (!window.SequraFE) {
             if (response.successMessage) {
                 container.prepend(utilities.createFlashMessage(response.successMessage, 'success'));
             }
-
-            return Promise.reject(response);
         };
 
         /**

--- a/dist/resources/js/StateController.js
+++ b/dist/resources/js/StateController.js
@@ -277,7 +277,7 @@ SequraFE.appPages = {
                 switch (page) {
                     case SequraFE.appPages.ONBOARDING.COUNTRIES:
                         if (!dataStore.connectionSettings?.connectionData?.every(c => c.username)) {
-                            page = SequraFE.appPages.ONBOARDING.CONNECT
+                            page = SequraFE.appPages.ONBOARDING.CONNECT;
                         }
 
                         if (!dataStore.deploymentsSettings?.some(deployment => deployment.active === true)) {

--- a/dist/resources/lang/en.json
+++ b/dist/resources/lang/en.json
@@ -172,6 +172,11 @@
     "deployments": {
       "manage": "Manage Deployment Targets"
     },
+    "webhookReRegistration": {
+      "title": "Re-register webhooks",
+      "successMessage": "Webhooks were re-registered successfully.",
+      "errorMessage": "Webhooks were not re-registered successfully."
+    },
     "username": {
       "label": "Username",
       "description": "You can find your username in the email sent by SeQura."

--- a/dist/resources/lang/en.json
+++ b/dist/resources/lang/en.json
@@ -172,11 +172,6 @@
     "deployments": {
       "manage": "Manage Deployment Targets"
     },
-    "webhookReRegistration": {
-      "title": "Re-register webhooks",
-      "successMessage": "Webhooks were re-registered successfully.",
-      "errorMessage": "Webhooks were not re-registered successfully."
-    },
     "username": {
       "label": "Username",
       "description": "You can find your username in the email sent by SeQura."
@@ -198,6 +193,11 @@
     "disconnect": {
       "title": "Disconnect",
       "message": "Are you sure you want to disconnect?"
+    },
+    "webhookReRegistration": {
+      "title": "Re-register webhooks",
+      "successMessage": "Webhooks were re-registered successfully.",
+      "errorMessage": "Webhooks were not re-registered successfully."
     }
   },
   "deployments": {

--- a/dist/resources/lang/es.json
+++ b/dist/resources/lang/es.json
@@ -192,6 +192,11 @@
     "disconnect": {
       "title": "Desconectar",
       "message": "¿Estás seguro de que deseas desconectarte?"
+    },
+    "webhookReRegistration": {
+      "title": "Volver a registrar webhooks",
+      "successMessage": "Los webhooks se registraron nuevamente con éxito.",
+      "errorMessage": "No se pudieron volver a registrar los webhooks."
     }
   },
   "deployments": {

--- a/dist/resources/lang/fr.json
+++ b/dist/resources/lang/fr.json
@@ -193,6 +193,11 @@
     "disconnect": {
       "title": "Déconnecter",
       "message": "Êtes-vous sûr de vouloir vous déconnecter ?"
+    },
+    "webhookReRegistration": {
+      "title": "Re-enregistrer les webhooks",
+      "successMessage": "Les webhooks ont été réenregistrés avec succès.",
+      "errorMessage": "Les webhooks n’ont pas pu être réenregistrés avec succès."
     }
   },
   "deployments": {

--- a/dist/resources/lang/it.json
+++ b/dist/resources/lang/it.json
@@ -193,6 +193,11 @@
     "disconnect": {
       "title": "Disconnetti",
       "message": "Sei sicuro di volerti disconnettere?"
+    },
+    "webhookReRegistration": {
+      "title": "Registrare nuovamente i webhook",
+      "successMessage": "I webhook sono stati registrati nuovamente con successo.",
+      "errorMessage": "Non è stato possibile registrare nuovamente i webhook."
     }
   },
   "deployments": {

--- a/dist/resources/lang/pt.json
+++ b/dist/resources/lang/pt.json
@@ -194,6 +194,11 @@
     "disconnect": {
       "title": "Desconectar",
       "message": "Tem a certeza de que se quer desconectar?"
+    },
+    "webhookReRegistration": {
+      "title": "Registrar novamente os webhooks",
+      "successMessage": "Os webhooks foram registrados novamente com sucesso.",
+      "errorMessage": "Não foi possível registrar novamente os webhooks."
     }
   },
   "deployments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sequra-core-admin-fe",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sequra-core-admin-fe",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "json-formatter-js": "^2.5.23",
         "simple-datatables": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequra-core-admin-fe",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "scripts": {
     "copy-dist-js": "cp ./src/services/* ./src/components/**/*.js ./src/controllers/*.js ./src/forms/*.js ./dist/resources/js",
     "copy-dist-assets": "cp -r ./src/design/assets ./src/lang ./dist/resources",

--- a/src/controllers/AdvancedController.js
+++ b/src/controllers/AdvancedController.js
@@ -303,7 +303,7 @@ if (!window.SequraFE) {
 
             const resetDetails = () => {
                 document.querySelectorAll('.sqm--log-context').forEach(elem => {
-                    elem.style.display = 'none'
+                    elem.style.display = 'none';
                     elem.innerHTML = '';
                 });
                 document.querySelectorAll('.sqm--log-details').forEach(elem => {

--- a/src/controllers/OnboardingController.js
+++ b/src/controllers/OnboardingController.js
@@ -145,10 +145,9 @@ if (!window.SequraFE) {
         /**
          * Renders the widgets settings form.
          *
-         * @param paymentMethods
          * @param allAvailablePaymentMethods
          */
-        const renderWidgetSettingsForm = (paymentMethods, allAvailablePaymentMethods) => {
+        const renderWidgetSettingsForm = (allAvailablePaymentMethods) => {
             if (!SequraFE.state.getData('allAvailablePaymentMethods')) {
                 SequraFE.state.setData('allAvailablePaymentMethods', allAvailablePaymentMethods)
             }

--- a/src/controllers/StateController.js
+++ b/src/controllers/StateController.js
@@ -277,7 +277,7 @@ SequraFE.appPages = {
                 switch (page) {
                     case SequraFE.appPages.ONBOARDING.COUNTRIES:
                         if (!dataStore.connectionSettings?.connectionData?.every(c => c.username)) {
-                            page = SequraFE.appPages.ONBOARDING.CONNECT
+                            page = SequraFE.appPages.ONBOARDING.CONNECT;
                         }
 
                         if (!dataStore.deploymentsSettings?.some(deployment => deployment.active === true)) {

--- a/src/design/components/field-wrapper.scss
+++ b/src/design/components/field-wrapper.scss
@@ -118,6 +118,11 @@
 
     &.sqm--bellow-frame {
       margin-top: 30px;
+
+      .sqm--actions-bar {
+        display: flex;
+        gap: 6px;
+      }
     }
   }
 

--- a/src/forms/ConnectionSettingsForm.js
+++ b/src/forms/ConnectionSettingsForm.js
@@ -29,6 +29,7 @@ if (!window.SequraFE) {
      * connectUrl: string,
      * validateConnectionDataUrl: string,
      * disconnectUrl: string,
+     * reRegisterUrl: string,
      * page: string,
      * appState: string
      * }} configuration
@@ -316,15 +317,31 @@ if (!window.SequraFE) {
                 return;
             }
 
-            pageInnerContent?.append(
-                generator.createButtonField({
-                    className: 'sqm--block sqm--bellow-frame',
-                    buttonType: 'danger',
-                    buttonSize: 'medium',
-                    buttonLabel: 'general.disconnect',
-                    onClick: handleDisconnect
-                })
-            );
+            const reRegisterWebhooksButton = generator.createButton({
+                type: 'secondary',
+                size: 'medium',
+                className: '',
+                onClick: handleReRegister,
+                label: 'Re-register webhooks'
+            })
+
+            const disconnectionButton = generator.createButton({
+                type: 'danger',
+                size: 'medium',
+                className: '',
+                onClick: handleDisconnect,
+                label: 'general.disconnect'
+            })
+
+            const actionsBar = generator.createActionsBar(
+                'sqm--block sqm--bellow-frame',
+                [
+                    reRegisterWebhooksButton,
+                    disconnectionButton
+                ]
+            )
+
+            pageInnerContent?.append(actionsBar);
 
             pageContent?.append(
                 generator.createPageFooter({
@@ -555,7 +572,7 @@ if (!window.SequraFE) {
 
                 utilities.showLoader();
 
-                api.post(configuration.disconnectUrl, createPayload(), SequraFE.customHeader)
+                api.post(configuration.disconnectUrl, createDisconnectionPayload(), SequraFE.customHeader)
                     .then(() => SequraFE.state.display())
                     .finally(utilities.hideLoader);
             })
@@ -564,7 +581,37 @@ if (!window.SequraFE) {
         /**
          * Handles the disconnect button click.
          */
-        const createPayload = () => {
+        const handleReRegister = () => {
+            utilities.showLoader();
+
+            api.post(configuration.reRegisterUrl, createReRegisterPayload(), SequraFE.customHeader)
+                .then((response) => {
+                    if (response.isSuccessful) {
+                        SequraFE.responseService.successHandler(
+                            {successMessage: 'connection.webhookReRegistration.successMessage'}
+                        ).catch(() => {
+                        });
+                    } else {
+                        SequraFE.responseService.errorHandler(
+                            {errorMessage: 'connection.webhookReRegistration.errorMessage'}
+                        ).catch(() => {
+                        });
+                    }
+
+                })
+                .catch((error) => {
+                    SequraFE.responseService.errorHandler(
+                        {errorMessage: error}
+                    ).catch(() => {
+                    });
+                })
+                .finally(utilities.hideLoader);
+        }
+
+        /**
+         * Creates connection payload.
+         */
+        const createDisconnectionPayload = () => {
             const isFullDisconnect = activeDeployments.length <= 1;
             const deploymentId = activeDeploymentId;
 
@@ -574,6 +621,22 @@ if (!window.SequraFE) {
             };
         }
 
+        /**
+         * Creates payload for webhook re-registration.
+         */
+        const createReRegisterPayload = () => {
+            const environment = changedSettings.environment ?? 'sandbox';
+            const username = getSettingsForActiveDeployment(changedSettings).username ?? '';
+            const password = getSettingsForActiveDeployment(changedSettings).password ?? '';
+            const deployment = getSettingsForActiveDeployment(changedSettings).deployment ?? '';
+
+            return {
+                environment,
+                username,
+                password,
+                deployment
+            };
+        }
 
         /**
          * Disables the form footer controls.

--- a/src/forms/ConnectionSettingsForm.js
+++ b/src/forms/ConnectionSettingsForm.js
@@ -589,8 +589,7 @@ if (!window.SequraFE) {
                     if (response.isSuccessful) {
                         SequraFE.responseService.successHandler(
                             {successMessage: 'connection.webhookReRegistration.successMessage'}
-                        ).catch(() => {
-                        });
+                        )
                     } else {
                         SequraFE.responseService.errorHandler(
                             {errorMessage: 'connection.webhookReRegistration.errorMessage'}
@@ -600,8 +599,9 @@ if (!window.SequraFE) {
 
                 })
                 .catch((error) => {
+                    const errorMessage = String(error && error.message ? error.message : error);
                     SequraFE.responseService.errorHandler(
-                        {errorMessage: error}
+                        {errorMessage: errorMessage}
                     ).catch(() => {
                     });
                 })

--- a/src/forms/GeneralSettingsForm.js
+++ b/src/forms/GeneralSettingsForm.js
@@ -430,7 +430,7 @@ if (!window.SequraFE) {
             }
 
             // Update the visibility of the fields.
-            const selector = '.sq-field-wrapper:has(.sq-service-related-field), .sq-field-wrapper.sq-service-related-field'
+            const selector = '.sq-field-wrapper:has(.sq-service-related-field), .sq-field-wrapper.sq-service-related-field';
             const hiddenClass = 'sqs--hidden';
             document.querySelectorAll(selector).forEach((el) => {
                 if (changedGeneralSettings.enabledForServices.length > 0) {

--- a/src/forms/GeneralSettingsForm.js
+++ b/src/forms/GeneralSettingsForm.js
@@ -397,7 +397,7 @@ if (!window.SequraFE) {
                     }
                 }
                 return countriesString ? translate('countries.enabledCountries').replace('{countries}', countriesString) : '';
-            }
+            };
             const descriptionWithCountries = (description, countries) => SequraFE.translationService.translate(description) + countriesString(countries);
 
             const enabledForServiceInput = document.querySelector(`.${classNameEnabledForService} input`);

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -172,6 +172,11 @@
     "deployments": {
       "manage": "Manage Deployment Targets"
     },
+    "webhookReRegistration": {
+      "title": "Re-register webhooks",
+      "successMessage": "Webhooks were re-registered successfully.",
+      "errorMessage": "Webhooks were not re-registered successfully."
+    },
     "username": {
       "label": "Username",
       "description": "You can find your username in the email sent by SeQura."

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -172,11 +172,6 @@
     "deployments": {
       "manage": "Manage Deployment Targets"
     },
-    "webhookReRegistration": {
-      "title": "Re-register webhooks",
-      "successMessage": "Webhooks were re-registered successfully.",
-      "errorMessage": "Webhooks were not re-registered successfully."
-    },
     "username": {
       "label": "Username",
       "description": "You can find your username in the email sent by SeQura."
@@ -198,6 +193,11 @@
     "disconnect": {
       "title": "Disconnect",
       "message": "Are you sure you want to disconnect?"
+    },
+    "webhookReRegistration": {
+      "title": "Re-register webhooks",
+      "successMessage": "Webhooks were re-registered successfully.",
+      "errorMessage": "Webhooks were not re-registered successfully."
     }
   },
   "deployments": {

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -192,6 +192,11 @@
     "disconnect": {
       "title": "Desconectar",
       "message": "¿Estás seguro de que deseas desconectarte?"
+    },
+    "webhookReRegistration": {
+      "title": "Volver a registrar webhooks",
+      "successMessage": "Los webhooks se registraron nuevamente con éxito.",
+      "errorMessage": "No se pudieron volver a registrar los webhooks."
     }
   },
   "deployments": {

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -193,6 +193,11 @@
     "disconnect": {
       "title": "Déconnecter",
       "message": "Êtes-vous sûr de vouloir vous déconnecter ?"
+    },
+    "webhookReRegistration": {
+      "title": "Re-enregistrer les webhooks",
+      "successMessage": "Les webhooks ont été réenregistrés avec succès.",
+      "errorMessage": "Les webhooks n’ont pas pu être réenregistrés avec succès."
     }
   },
   "deployments": {

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -193,6 +193,11 @@
     "disconnect": {
       "title": "Disconnetti",
       "message": "Sei sicuro di volerti disconnettere?"
+    },
+    "webhookReRegistration": {
+      "title": "Registrare nuovamente i webhook",
+      "successMessage": "I webhook sono stati registrati nuovamente con successo.",
+      "errorMessage": "Non è stato possibile registrare nuovamente i webhook."
     }
   },
   "deployments": {

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -194,6 +194,11 @@
     "disconnect": {
       "title": "Desconectar",
       "message": "Tem a certeza de que se quer desconectar?"
+    },
+    "webhookReRegistration": {
+      "title": "Registrar novamente os webhooks",
+      "successMessage": "Os webhooks foram registrados novamente com sucesso.",
+      "errorMessage": "Não foi possível registrar novamente os webhooks."
     }
   },
   "deployments": {

--- a/src/services/ElementGenerator.js
+++ b/src/services/ElementGenerator.js
@@ -438,6 +438,20 @@ if (!window.SequraFE) {
         return createFieldWrapper(buttonLink, label, description, '', error, '');
     };
 
+
+    /**
+     * Adds bar with multiple action buttons.
+     *
+     * @returns HTMLElement
+     */
+    const createActionsBar = (className, children) => {
+        const fieldWrapper = createElement('div', 'sq-field-wrapper ' + className)
+        const inputWrapper = createElement('div', 'sqm--actions-bar', '', null, children);
+        fieldWrapper.append(inputWrapper);
+
+        return fieldWrapper;
+    };
+
     /**
      * Creates multi item selector wrapper around the provided multi item selector element.
      *
@@ -691,6 +705,7 @@ if (!window.SequraFE) {
         createButtonField,
         createButtonLink,
         createButtonLinkField,
+        createActionsBar,
         createMultiItemSelectorField,
         createCountryField,
         createFormFields,

--- a/src/services/ElementGenerator.js
+++ b/src/services/ElementGenerator.js
@@ -685,7 +685,7 @@ if (!window.SequraFE) {
                 )
             ]
         );
-    }
+    };
 
     SequraFE.elementGenerator = {
         createElement,

--- a/src/services/ResponseService.js
+++ b/src/services/ResponseService.js
@@ -37,6 +37,29 @@ if (!window.SequraFE) {
         };
 
         /**
+         * Handles a success response from the submit action.
+         *
+         * @param {{successMessage?: string}} response
+         * @returns {Promise<void>}
+         */
+        this.successHandler = (response) => {
+            const {utilities, templateService, elementGenerator} = SequraFE;
+            let container = document.querySelector('.sqp-flash-message-wrapper');
+            if (!container) {
+                container = elementGenerator.createElement('div', 'sqp-flash-message-wrapper');
+                templateService.getMainPage().prepend(container);
+            }
+
+            templateService.clearComponent(container);
+
+            if (response.successMessage) {
+                container.prepend(utilities.createFlashMessage(response.successMessage, 'success'));
+            }
+
+            return Promise.reject(response);
+        };
+
+        /**
          * Handles unauthorized response.
          *
          * @param {{errorMessage?: string, errorCode?: string, statusCode?: number}} response

--- a/src/services/ResponseService.js
+++ b/src/services/ResponseService.js
@@ -40,7 +40,7 @@ if (!window.SequraFE) {
          * Handles a success response from the submit action.
          *
          * @param {{successMessage?: string}} response
-         * @returns {Promise<void>}
+         * @returns {void}
          */
         this.successHandler = (response) => {
             const {utilities, templateService, elementGenerator} = SequraFE;
@@ -55,8 +55,6 @@ if (!window.SequraFE) {
             if (response.successMessage) {
                 container.prepend(utilities.createFlashMessage(response.successMessage, 'success'));
             }
-
-            return Promise.reject(response);
         };
 
         /**


### PR DESCRIPTION
 ### What is the goal?

- Add a button for webhook re-registration on the Connection page.

### References
* **Issue:** [LIS-90](https://sequra.atlassian.net/browse/LIS-90)
 
### How is it being implemented?
- Added an action bar in ElementGenerator to allow multiple buttons to be displayed in the same row
- Added buttons for webhook re-registration and disconnection using the new ElementGenerator method
- Added a success response handler in ResponseService to process successful responses
- Implemented the logic to handle webhook re-registration

### How is it tested?
- Manual tests
   - Follow the README instructions for building the resources
   - Follow the README instructions for copying resources into the Shopify integration
   - Install the SeQura Marketing app in Shopify
   - Check the look and feel on the Connection settings page


[LIS-90]: https://sequra.atlassian.net/browse/LIS-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ