### PR TITLE
feat: add Affiliate settings section to the settings SPA (QRD-7902)

### DIFF
--- a/dist/resources/js/AffiliateSettingsForm.js
+++ b/dist/resources/js/AffiliateSettingsForm.js
@@ -1,0 +1,179 @@
+if (!window.SequraFE) {
+    window.SequraFE = {};
+}
+
+(function () {
+    /**
+     * @typedef AffiliateSettings
+     * @property {boolean} enabled
+     * @property {string} offerId
+     * @property {string} securityToken
+     */
+
+    /**
+     * Handles affiliate settings form logic.
+     *
+     * @param {{ affiliateSettings: AffiliateSettings }} data
+     * @param {{
+     * getAffiliateSettingsUrl: string,
+     * saveAffiliateSettingsUrl: string,
+     * page: string,
+     * appState: string,
+     * }} configuration
+     * @constructor
+     */
+    function AffiliateSettingsForm(data, configuration) {
+        const {
+            elementGenerator: generator,
+            validationService: validator,
+            translationService,
+            utilities
+        } = SequraFE;
+
+        /** @type AjaxServiceType */
+        const api = SequraFE.ajaxService;
+
+        /** @type AffiliateSettings */
+        const defaultFormData = {
+            enabled: false,
+            offerId: '',
+            securityToken: ''
+        };
+
+        /** @type AffiliateSettings */
+        let activeSettings;
+        /** @type AffiliateSettings */
+        let changedSettings;
+
+        /**
+         * Handles form rendering.
+         */
+        this.render = () => {
+            if (!activeSettings) {
+                activeSettings = utilities.cloneObject(defaultFormData);
+                for (let key in activeSettings) {
+                    activeSettings[key] = data?.affiliateSettings?.[key] ?? defaultFormData[key];
+                }
+            }
+
+            changedSettings = utilities.cloneObject(activeSettings);
+            initForm();
+            utilities.disableFooter(true);
+            utilities.hideLoader();
+        }
+
+        /**
+         * Initializes the form structure.
+         */
+        const initForm = () => {
+            const pageContent = document.querySelector('.sq-content');
+            pageContent?.append(
+                generator.createElement('div', 'sq-content-inner', '', null, [
+                    generator.createElement('div', 'sqp-flash-message-wrapper'),
+                    generator.createPageHeading({
+                        title: 'affiliate.title',
+                        text: 'affiliate.description'
+                    }),
+                    generator.createToggleField({
+                        value: changedSettings.enabled,
+                        label: 'affiliate.enable.label',
+                        description: 'affiliate.enable.description',
+                        onChange: (value) => handleChange('enabled', value)
+                    }),
+                    generator.createTextField({
+                        className: 'sq-text-input',
+                        name: 'offerId',
+                        value: changedSettings.offerId,
+                        label: 'affiliate.offerId.label',
+                        description: 'affiliate.offerId.description',
+                        placeholder: translationService.translate('affiliate.offerId.placeholder'),
+                        onChange: (value) => handleChange('offerId', value)
+                    }),
+                    generator.createTextField({
+                        className: 'sq-text-input',
+                        name: 'securityToken',
+                        value: changedSettings.securityToken,
+                        label: 'affiliate.securityToken.label',
+                        description: 'affiliate.securityToken.description',
+                        placeholder: translationService.translate('affiliate.securityToken.placeholder'),
+                        onChange: (value) => handleChange('securityToken', value)
+                    })
+                ])
+            );
+
+            document.querySelector('.sq-content')?.append(
+                generator.createPageFooter({
+                    onSave: handleSave,
+                    onCancel: () => {
+                        const pageContent = document.querySelector('.sq-content');
+                        while (pageContent?.firstChild) {
+                            pageContent?.removeChild(pageContent.firstChild);
+                        }
+                        this.render();
+                    }
+                })
+            );
+        }
+
+        /**
+         * Handles form input changes.
+         *
+         * @param {string} name
+         * @param {any} value
+         */
+        const handleChange = (name, value) => {
+            changedSettings[name] = value;
+            utilities.disableFooter(false);
+        }
+
+        /**
+         * Validates the form. Offer ID and Security Token are only required when enabled.
+         *
+         * @returns {boolean}
+         */
+        const isFormValid = () => {
+            if (!changedSettings.enabled) {
+                return true;
+            }
+
+            let valid = true;
+            const offerIdField = document.querySelector('[name="offerId"]');
+            const securityTokenField = document.querySelector('[name="securityToken"]');
+
+            if (!validator.validateRequiredField(offerIdField, 'validation.requiredField')) {
+                valid = false;
+            } else if (!/^[0-9]{1,4}$/.test(changedSettings.offerId)) {
+                validator.validateField(offerIdField, true, 'affiliate.offerId.invalidFormat');
+                valid = false;
+            }
+
+            if (!validator.validateRequiredField(securityTokenField, 'validation.requiredField')) {
+                valid = false;
+            } else if (!/^[a-zA-Z0-9]+$/.test(changedSettings.securityToken)) {
+                validator.validateField(securityTokenField, true, 'affiliate.securityToken.invalidFormat');
+                valid = false;
+            }
+
+            return valid;
+        }
+
+        /**
+         * Handles saving of the form.
+         */
+        const handleSave = () => {
+            if (!isFormValid()) {
+                return;
+            }
+
+            utilities.showLoader();
+            api.post(configuration.saveAffiliateSettingsUrl, changedSettings, SequraFE.customHeader)
+                .then(() => {
+                    activeSettings = utilities.cloneObject(changedSettings);
+                    utilities.disableFooter(true);
+                })
+                .finally(utilities.hideLoader);
+        }
+    }
+
+    SequraFE.AffiliateSettingsForm = AffiliateSettingsForm;
+})();

--- a/dist/resources/js/SettingsController.js
+++ b/dist/resources/js/SettingsController.js
@@ -19,6 +19,8 @@ if (!window.SequraFE) {
      * getAllAvailablePaymentMethodsUrl: string,
      * validateConnectionDataUrl: string,
      * disconnectUrl: string,
+     * getAffiliateSettingsUrl: string,
+     * saveAffiliateSettingsUrl: string,
      * page: string
      * }} configuration
      * @constructor
@@ -100,6 +102,12 @@ if (!window.SequraFE) {
                         SequraFE.state.getData('allAvailablePaymentMethods') ?? api.get(configuration.getAllAvailablePaymentMethodsUrl, null, SequraFE.customHeader),
                     ])
                     break;
+                case SequraFE.appPages.SETTINGS.AFFILIATE:
+                    renderer = renderAffiliateSettingsForm;
+                    promises = Promise.all([
+                        api.get(configuration.getAffiliateSettingsUrl, null, SequraFE.customHeader)
+                    ])
+                    break;
                 default:
                     renderer = renderGeneralSettingsForm;
                     promises = Promise.all([
@@ -173,6 +181,21 @@ if (!window.SequraFE) {
             const form = formFactory.getInstance(
                 'widgetSettings',
                 {widgetSettings, connectionSettings, countrySettings, paymentMethods, allAvailablePaymentMethods},
+                {...configuration, appState: SequraFE.appStates.SETTINGS}
+            );
+
+            form?.render();
+        }
+
+        /**
+         * Renders the affiliate settings form.
+         *
+         * @param affiliateSettings
+         */
+        const renderAffiliateSettingsForm = (affiliateSettings) => {
+            const form = formFactory.getInstance(
+                'affiliateSettings',
+                {affiliateSettings},
                 {...configuration, appState: SequraFE.appStates.SETTINGS}
             );
 
@@ -259,6 +282,13 @@ if (!window.SequraFE) {
                             href: '#settings-widget',
                             icon: 'widget',
                             isActive: activePage === SequraFE.appPages.SETTINGS.WIDGET
+                        }
+                    case SequraFE.appPages.SETTINGS.AFFILIATE:
+                        return {
+                            label: 'sidebar.affiliateSettings',
+                            href: '#settings-affiliate',
+                            icon: 'affiliate',
+                            isActive: activePage === SequraFE.appPages.SETTINGS.AFFILIATE
                         }
                 }
             });

--- a/dist/resources/js/StateController.js
+++ b/dist/resources/js/StateController.js
@@ -29,7 +29,8 @@ SequraFE.appPages = {
         GENERAL: 'general',
         CONNECTION: 'connection',
         ORDER_STATUS: 'order_status',
-        WIDGET: 'widget'
+        WIDGET: 'widget',
+        AFFILIATE: 'affiliate'
     },
     PAYMENT: {
         METHODS: 'methods'

--- a/dist/resources/lang/en.json
+++ b/dist/resources/lang/en.json
@@ -100,7 +100,8 @@
     "stepDeployments": "Select Deployment Targets",
     "stepThreeLabel": "Configure selling countries",
     "stepFourLabel": "Configure widgets",
-    "stepFiveLabel": "Start selling with SeQura"
+    "stepFiveLabel": "Start selling with SeQura",
+    "affiliateSettings": "Affiliate"
   },
   "validation": {
     "requiredField": "This field is required.",
@@ -389,5 +390,25 @@
   "supportLink": {
     "label": "Need help?",
     "link": "https://sqra.es/supportes"
+  },
+  "affiliate": {
+    "title": "Affiliate",
+    "description": "Configure the seQura affiliate tracking for this store.",
+    "enable": {
+      "label": "Enable affiliate tracking",
+      "description": "Enable seQura affiliate conversion tracking."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "The seQura affiliate offer ID.",
+      "placeholder": "Enter your Offer ID",
+      "invalidFormat": "Offer ID must be numeric (max 4 digits)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "The seQura affiliate security token.",
+      "placeholder": "Enter your Security Token",
+      "invalidFormat": "Security Token must contain only alphanumeric characters."
+    }
   }
 }

--- a/dist/resources/lang/es.json
+++ b/dist/resources/lang/es.json
@@ -99,7 +99,8 @@
     "stepTwoLabel": "Conectar integración",
     "stepThreeLabel": "Configurar países de venta",
     "stepFourLabel": "Configurar widgets",
-    "stepFiveLabel": "Comienza a vender con SeQura"
+    "stepFiveLabel": "Comienza a vender con SeQura",
+    "affiliateSettings": "Afiliación"
   },
   "validation": {
     "requiredField": "Este campo es obligatorio.",
@@ -388,5 +389,25 @@
   "supportLink": {
     "label": "¿Necesitas ayuda?",
     "link": "https://sqra.es/supportes"
+  },
+  "affiliate": {
+    "title": "Afiliación",
+    "description": "Configura el seguimiento de afiliación de seQura para esta tienda.",
+    "enable": {
+      "label": "Activar seguimiento de afiliación",
+      "description": "Activa el seguimiento de conversiones de afiliación de seQura."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "El Offer ID de afiliación de seQura.",
+      "placeholder": "Introduce tu Offer ID",
+      "invalidFormat": "El Offer ID debe ser numérico (máx. 4 dígitos)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "El Security Token de afiliación de seQura.",
+      "placeholder": "Introduce tu Security Token",
+      "invalidFormat": "El Security Token solo puede contener caracteres alfanuméricos."
+    }
   }
 }

--- a/dist/resources/lang/fr.json
+++ b/dist/resources/lang/fr.json
@@ -100,7 +100,8 @@
     "stepDeployments": "Sélectionner les cibles de déploiement",
     "stepThreeLabel": "Configurer les pays de vente",
     "stepFourLabel": "Configurer les widgets",
-    "stepFiveLabel": "Commencez à vendre avec SeQura"
+    "stepFiveLabel": "Commencez à vendre avec SeQura",
+    "affiliateSettings": "Affiliation"
   },
   "validation": {
     "requiredField": "Ce champ est obligatoire.",
@@ -389,5 +390,25 @@
   "supportLink": {
     "label": "Besoin d'aide ?",
     "link": "https://sqra.es/supportfr"
+  },
+  "affiliate": {
+    "title": "Affiliation",
+    "description": "Configurez le suivi d'affiliation seQura pour cette boutique.",
+    "enable": {
+      "label": "Activer le suivi d'affiliation",
+      "description": "Activer le suivi des conversions d'affiliation seQura."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "L'Offer ID d'affiliation seQura.",
+      "placeholder": "Saisissez votre Offer ID",
+      "invalidFormat": "L'Offer ID doit être numérique (max 4 chiffres)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "Le Security Token d'affiliation seQura.",
+      "placeholder": "Saisissez votre Security Token",
+      "invalidFormat": "Le Security Token ne peut contenir que des caractères alphanumériques."
+    }
   }
 }

--- a/dist/resources/lang/it.json
+++ b/dist/resources/lang/it.json
@@ -100,7 +100,8 @@
     "stepDeployments": "Seleziona target di distribuzione",
     "stepThreeLabel": "Configura paesi di vendita",
     "stepFourLabel": "Configura widget",
-    "stepFiveLabel": "Inizia a vendere con SeQura"
+    "stepFiveLabel": "Inizia a vendere con SeQura",
+    "affiliateSettings": "Affiliazione"
   },
   "validation": {
     "requiredField": "Questo campo è obbligatorio.",
@@ -389,5 +390,25 @@
   "supportLink": {
     "label": "Hai bisogno di aiuto?",
     "link": "https://sqra.es/supportit"
+  },
+  "affiliate": {
+    "title": "Affiliazione",
+    "description": "Configura il tracciamento di affiliazione di seQura per questo negozio.",
+    "enable": {
+      "label": "Abilita il tracciamento di affiliazione",
+      "description": "Abilita il tracciamento delle conversioni di affiliazione di seQura."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "L'Offer ID di affiliazione di seQura.",
+      "placeholder": "Inserisci il tuo Offer ID",
+      "invalidFormat": "L'Offer ID deve essere numerico (max 4 cifre)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "Il Security Token di affiliazione di seQura.",
+      "placeholder": "Inserisci il tuo Security Token",
+      "invalidFormat": "Il Security Token può contenere solo caratteri alfanumerici."
+    }
   }
 }

--- a/dist/resources/lang/pt.json
+++ b/dist/resources/lang/pt.json
@@ -101,7 +101,8 @@
     "stepThreeLabel": "Configurar widgets",
     "stepThreeDescription": "Configure os widgets do SeQura para a sua loja.",
     "stepFourLabel": "Configurar estados do pedido",
-    "stepFourDescription": "Configure os estados do pedido no SeQura."
+    "stepFourDescription": "Configure os estados do pedido no SeQura.",
+    "affiliateSettings": "Afiliação"
   },
   "validation": {
     "requiredField": "Este campo é obrigatório.",
@@ -390,5 +391,25 @@
   "supportLink": {
     "label": "Precisa de ajuda?",
     "link": "https://sqra.es/supportpt"
+  },
+  "affiliate": {
+    "title": "Afiliação",
+    "description": "Configure o rastreamento de afiliação da seQura para esta loja.",
+    "enable": {
+      "label": "Ativar rastreamento de afiliação",
+      "description": "Ativar o rastreamento de conversões de afiliação da seQura."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "O Offer ID de afiliação da seQura.",
+      "placeholder": "Introduza o seu Offer ID",
+      "invalidFormat": "O Offer ID deve ser numérico (máx. 4 dígitos)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "O Security Token de afiliação da seQura.",
+      "placeholder": "Introduza o seu Security Token",
+      "invalidFormat": "O Security Token só pode conter caracteres alfanuméricos."
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequra-core-admin-fe",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "scripts": {
     "copy-dist-js": "cp ./src/services/* ./src/components/**/*.js ./src/controllers/*.js ./src/forms/*.js ./dist/resources/js",
     "copy-dist-assets": "cp -r ./src/design/assets ./src/lang ./dist/resources",

--- a/src/controllers/SettingsController.js
+++ b/src/controllers/SettingsController.js
@@ -19,6 +19,8 @@ if (!window.SequraFE) {
      * getAllAvailablePaymentMethodsUrl: string,
      * validateConnectionDataUrl: string,
      * disconnectUrl: string,
+     * getAffiliateSettingsUrl: string,
+     * saveAffiliateSettingsUrl: string,
      * page: string
      * }} configuration
      * @constructor
@@ -100,6 +102,12 @@ if (!window.SequraFE) {
                         SequraFE.state.getData('allAvailablePaymentMethods') ?? api.get(configuration.getAllAvailablePaymentMethodsUrl, null, SequraFE.customHeader),
                     ])
                     break;
+                case SequraFE.appPages.SETTINGS.AFFILIATE:
+                    renderer = renderAffiliateSettingsForm;
+                    promises = Promise.all([
+                        api.get(configuration.getAffiliateSettingsUrl, null, SequraFE.customHeader)
+                    ])
+                    break;
                 default:
                     renderer = renderGeneralSettingsForm;
                     promises = Promise.all([
@@ -173,6 +181,21 @@ if (!window.SequraFE) {
             const form = formFactory.getInstance(
                 'widgetSettings',
                 {widgetSettings, connectionSettings, countrySettings, paymentMethods, allAvailablePaymentMethods},
+                {...configuration, appState: SequraFE.appStates.SETTINGS}
+            );
+
+            form?.render();
+        }
+
+        /**
+         * Renders the affiliate settings form.
+         *
+         * @param affiliateSettings
+         */
+        const renderAffiliateSettingsForm = (affiliateSettings) => {
+            const form = formFactory.getInstance(
+                'affiliateSettings',
+                {affiliateSettings},
                 {...configuration, appState: SequraFE.appStates.SETTINGS}
             );
 
@@ -259,6 +282,13 @@ if (!window.SequraFE) {
                             href: '#settings-widget',
                             icon: 'widget',
                             isActive: activePage === SequraFE.appPages.SETTINGS.WIDGET
+                        }
+                    case SequraFE.appPages.SETTINGS.AFFILIATE:
+                        return {
+                            label: 'sidebar.affiliateSettings',
+                            href: '#settings-affiliate',
+                            icon: 'affiliate',
+                            isActive: activePage === SequraFE.appPages.SETTINGS.AFFILIATE
                         }
                 }
             });

--- a/src/controllers/StateController.js
+++ b/src/controllers/StateController.js
@@ -29,7 +29,8 @@ SequraFE.appPages = {
         GENERAL: 'general',
         CONNECTION: 'connection',
         ORDER_STATUS: 'order_status',
-        WIDGET: 'widget'
+        WIDGET: 'widget',
+        AFFILIATE: 'affiliate'
     },
     PAYMENT: {
         METHODS: 'methods'

--- a/src/forms/AffiliateSettingsForm.js
+++ b/src/forms/AffiliateSettingsForm.js
@@ -1,0 +1,179 @@
+if (!window.SequraFE) {
+    window.SequraFE = {};
+}
+
+(function () {
+    /**
+     * @typedef AffiliateSettings
+     * @property {boolean} enabled
+     * @property {string} offerId
+     * @property {string} securityToken
+     */
+
+    /**
+     * Handles affiliate settings form logic.
+     *
+     * @param {{ affiliateSettings: AffiliateSettings }} data
+     * @param {{
+     * getAffiliateSettingsUrl: string,
+     * saveAffiliateSettingsUrl: string,
+     * page: string,
+     * appState: string,
+     * }} configuration
+     * @constructor
+     */
+    function AffiliateSettingsForm(data, configuration) {
+        const {
+            elementGenerator: generator,
+            validationService: validator,
+            translationService,
+            utilities
+        } = SequraFE;
+
+        /** @type AjaxServiceType */
+        const api = SequraFE.ajaxService;
+
+        /** @type AffiliateSettings */
+        const defaultFormData = {
+            enabled: false,
+            offerId: '',
+            securityToken: ''
+        };
+
+        /** @type AffiliateSettings */
+        let activeSettings;
+        /** @type AffiliateSettings */
+        let changedSettings;
+
+        /**
+         * Handles form rendering.
+         */
+        this.render = () => {
+            if (!activeSettings) {
+                activeSettings = utilities.cloneObject(defaultFormData);
+                for (let key in activeSettings) {
+                    activeSettings[key] = data?.affiliateSettings?.[key] ?? defaultFormData[key];
+                }
+            }
+
+            changedSettings = utilities.cloneObject(activeSettings);
+            initForm();
+            utilities.disableFooter(true);
+            utilities.hideLoader();
+        }
+
+        /**
+         * Initializes the form structure.
+         */
+        const initForm = () => {
+            const pageContent = document.querySelector('.sq-content');
+            pageContent?.append(
+                generator.createElement('div', 'sq-content-inner', '', null, [
+                    generator.createElement('div', 'sqp-flash-message-wrapper'),
+                    generator.createPageHeading({
+                        title: 'affiliate.title',
+                        text: 'affiliate.description'
+                    }),
+                    generator.createToggleField({
+                        value: changedSettings.enabled,
+                        label: 'affiliate.enable.label',
+                        description: 'affiliate.enable.description',
+                        onChange: (value) => handleChange('enabled', value)
+                    }),
+                    generator.createTextField({
+                        className: 'sq-text-input',
+                        name: 'offerId',
+                        value: changedSettings.offerId,
+                        label: 'affiliate.offerId.label',
+                        description: 'affiliate.offerId.description',
+                        placeholder: translationService.translate('affiliate.offerId.placeholder'),
+                        onChange: (value) => handleChange('offerId', value)
+                    }),
+                    generator.createTextField({
+                        className: 'sq-text-input',
+                        name: 'securityToken',
+                        value: changedSettings.securityToken,
+                        label: 'affiliate.securityToken.label',
+                        description: 'affiliate.securityToken.description',
+                        placeholder: translationService.translate('affiliate.securityToken.placeholder'),
+                        onChange: (value) => handleChange('securityToken', value)
+                    })
+                ])
+            );
+
+            document.querySelector('.sq-content')?.append(
+                generator.createPageFooter({
+                    onSave: handleSave,
+                    onCancel: () => {
+                        const pageContent = document.querySelector('.sq-content');
+                        while (pageContent?.firstChild) {
+                            pageContent?.removeChild(pageContent.firstChild);
+                        }
+                        this.render();
+                    }
+                })
+            );
+        }
+
+        /**
+         * Handles form input changes.
+         *
+         * @param {string} name
+         * @param {any} value
+         */
+        const handleChange = (name, value) => {
+            changedSettings[name] = value;
+            utilities.disableFooter(false);
+        }
+
+        /**
+         * Validates the form. Offer ID and Security Token are only required when enabled.
+         *
+         * @returns {boolean}
+         */
+        const isFormValid = () => {
+            if (!changedSettings.enabled) {
+                return true;
+            }
+
+            let valid = true;
+            const offerIdField = document.querySelector('[name="offerId"]');
+            const securityTokenField = document.querySelector('[name="securityToken"]');
+
+            if (!validator.validateRequiredField(offerIdField, 'validation.requiredField')) {
+                valid = false;
+            } else if (!/^[0-9]{1,4}$/.test(changedSettings.offerId)) {
+                validator.validateField(offerIdField, true, 'affiliate.offerId.invalidFormat');
+                valid = false;
+            }
+
+            if (!validator.validateRequiredField(securityTokenField, 'validation.requiredField')) {
+                valid = false;
+            } else if (!/^[a-zA-Z0-9]+$/.test(changedSettings.securityToken)) {
+                validator.validateField(securityTokenField, true, 'affiliate.securityToken.invalidFormat');
+                valid = false;
+            }
+
+            return valid;
+        }
+
+        /**
+         * Handles saving of the form.
+         */
+        const handleSave = () => {
+            if (!isFormValid()) {
+                return;
+            }
+
+            utilities.showLoader();
+            api.post(configuration.saveAffiliateSettingsUrl, changedSettings, SequraFE.customHeader)
+                .then(() => {
+                    activeSettings = utilities.cloneObject(changedSettings);
+                    utilities.disableFooter(true);
+                })
+                .finally(utilities.hideLoader);
+        }
+    }
+
+    SequraFE.AffiliateSettingsForm = AffiliateSettingsForm;
+})();

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -100,7 +100,8 @@
     "stepDeployments": "Select Deployment Targets",
     "stepThreeLabel": "Configure selling countries",
     "stepFourLabel": "Configure widgets",
-    "stepFiveLabel": "Start selling with SeQura"
+    "stepFiveLabel": "Start selling with SeQura",
+    "affiliateSettings": "Affiliate"
   },
   "validation": {
     "requiredField": "This field is required.",
@@ -389,5 +390,25 @@
   "supportLink": {
     "label": "Need help?",
     "link": "https://sqra.es/supportes"
+  },
+  "affiliate": {
+    "title": "Affiliate",
+    "description": "Configure the seQura affiliate tracking for this store.",
+    "enable": {
+      "label": "Enable affiliate tracking",
+      "description": "Enable seQura affiliate conversion tracking."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "The seQura affiliate offer ID.",
+      "placeholder": "Enter your Offer ID",
+      "invalidFormat": "Offer ID must be numeric (max 4 digits)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "The seQura affiliate security token.",
+      "placeholder": "Enter your Security Token",
+      "invalidFormat": "Security Token must contain only alphanumeric characters."
+    }
   }
 }

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -99,7 +99,8 @@
     "stepTwoLabel": "Conectar integración",
     "stepThreeLabel": "Configurar países de venta",
     "stepFourLabel": "Configurar widgets",
-    "stepFiveLabel": "Comienza a vender con SeQura"
+    "stepFiveLabel": "Comienza a vender con SeQura",
+    "affiliateSettings": "Afiliación"
   },
   "validation": {
     "requiredField": "Este campo es obligatorio.",
@@ -388,5 +389,25 @@
   "supportLink": {
     "label": "¿Necesitas ayuda?",
     "link": "https://sqra.es/supportes"
+  },
+  "affiliate": {
+    "title": "Afiliación",
+    "description": "Configura el seguimiento de afiliación de seQura para esta tienda.",
+    "enable": {
+      "label": "Activar seguimiento de afiliación",
+      "description": "Activa el seguimiento de conversiones de afiliación de seQura."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "El Offer ID de afiliación de seQura.",
+      "placeholder": "Introduce tu Offer ID",
+      "invalidFormat": "El Offer ID debe ser numérico (máx. 4 dígitos)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "El Security Token de afiliación de seQura.",
+      "placeholder": "Introduce tu Security Token",
+      "invalidFormat": "El Security Token solo puede contener caracteres alfanuméricos."
+    }
   }
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -100,7 +100,8 @@
     "stepDeployments": "Sélectionner les cibles de déploiement",
     "stepThreeLabel": "Configurer les pays de vente",
     "stepFourLabel": "Configurer les widgets",
-    "stepFiveLabel": "Commencez à vendre avec SeQura"
+    "stepFiveLabel": "Commencez à vendre avec SeQura",
+    "affiliateSettings": "Affiliation"
   },
   "validation": {
     "requiredField": "Ce champ est obligatoire.",
@@ -389,5 +390,25 @@
   "supportLink": {
     "label": "Besoin d'aide ?",
     "link": "https://sqra.es/supportfr"
+  },
+  "affiliate": {
+    "title": "Affiliation",
+    "description": "Configurez le suivi d'affiliation seQura pour cette boutique.",
+    "enable": {
+      "label": "Activer le suivi d'affiliation",
+      "description": "Activer le suivi des conversions d'affiliation seQura."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "L'Offer ID d'affiliation seQura.",
+      "placeholder": "Saisissez votre Offer ID",
+      "invalidFormat": "L'Offer ID doit être numérique (max 4 chiffres)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "Le Security Token d'affiliation seQura.",
+      "placeholder": "Saisissez votre Security Token",
+      "invalidFormat": "Le Security Token ne peut contenir que des caractères alphanumériques."
+    }
   }
 }

--- a/src/lang/it.json
+++ b/src/lang/it.json
@@ -100,7 +100,8 @@
     "stepDeployments": "Seleziona target di distribuzione",
     "stepThreeLabel": "Configura paesi di vendita",
     "stepFourLabel": "Configura widget",
-    "stepFiveLabel": "Inizia a vendere con SeQura"
+    "stepFiveLabel": "Inizia a vendere con SeQura",
+    "affiliateSettings": "Affiliazione"
   },
   "validation": {
     "requiredField": "Questo campo è obbligatorio.",
@@ -389,5 +390,25 @@
   "supportLink": {
     "label": "Hai bisogno di aiuto?",
     "link": "https://sqra.es/supportit"
+  },
+  "affiliate": {
+    "title": "Affiliazione",
+    "description": "Configura il tracciamento di affiliazione di seQura per questo negozio.",
+    "enable": {
+      "label": "Abilita il tracciamento di affiliazione",
+      "description": "Abilita il tracciamento delle conversioni di affiliazione di seQura."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "L'Offer ID di affiliazione di seQura.",
+      "placeholder": "Inserisci il tuo Offer ID",
+      "invalidFormat": "L'Offer ID deve essere numerico (max 4 cifre)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "Il Security Token di affiliazione di seQura.",
+      "placeholder": "Inserisci il tuo Security Token",
+      "invalidFormat": "Il Security Token può contenere solo caratteri alfanumerici."
+    }
   }
 }

--- a/src/lang/pt.json
+++ b/src/lang/pt.json
@@ -101,7 +101,8 @@
     "stepThreeLabel": "Configurar widgets",
     "stepThreeDescription": "Configure os widgets do SeQura para a sua loja.",
     "stepFourLabel": "Configurar estados do pedido",
-    "stepFourDescription": "Configure os estados do pedido no SeQura."
+    "stepFourDescription": "Configure os estados do pedido no SeQura.",
+    "affiliateSettings": "Afiliação"
   },
   "validation": {
     "requiredField": "Este campo é obrigatório.",
@@ -390,5 +391,25 @@
   "supportLink": {
     "label": "Precisa de ajuda?",
     "link": "https://sqra.es/supportpt"
+  },
+  "affiliate": {
+    "title": "Afiliação",
+    "description": "Configure o rastreamento de afiliação da seQura para esta loja.",
+    "enable": {
+      "label": "Ativar rastreamento de afiliação",
+      "description": "Ativar o rastreamento de conversões de afiliação da seQura."
+    },
+    "offerId": {
+      "label": "Offer ID",
+      "description": "O Offer ID de afiliação da seQura.",
+      "placeholder": "Introduza o seu Offer ID",
+      "invalidFormat": "O Offer ID deve ser numérico (máx. 4 dígitos)."
+    },
+    "securityToken": {
+      "label": "Security Token",
+      "description": "O Security Token de afiliação da seQura.",
+      "placeholder": "Introduza o seu Security Token",
+      "invalidFormat": "O Security Token só pode conter caracteres alfanuméricos."
+    }
   }
 }


### PR DESCRIPTION
### What is the goal?

Add an opt-in **Affiliate** settings section to the shared admin settings SPA, so the seQura payment plugins can expose affiliate configuration (enable toggle, Offer ID, Security Token) inside their existing settings page. Companion of [QRD-7902](https://sequra.atlassian.net/browse/QRD-7902); consumed by the WooCommerce payment plugin PR (`woocommerce-sequra` #163, [QRD-7898](https://sequra.atlassian.net/browse/QRD-7898)).

### Changes

- `src/controllers/StateController.js` — new `appPages.SETTINGS.AFFILIATE`.
- `src/controllers/SettingsController.js` — `case AFFILIATE` in `renderPage()` (GET `getAffiliateSettingsUrl`), `renderAffiliateSettingsForm`, sidebar link in `getLinkConfiguration`, and the two config URLs in the JSDoc.
- `src/forms/AffiliateSettingsForm.js` (new) — enable toggle, Offer ID (numeric, ≤4), Security Token (**alphanumeric**); saves via POST to `saveAffiliateSettingsUrl`. Built on the same `elementGenerator`/`validationService` pattern as the existing forms.
- `src/lang/{en,es,it,fr,pt}.json` — `sidebar.affiliateSettings` + `affiliate.*` keys.
- `package.json` — version bump `2.3.0` → `2.4.0`.

### Does this break other integrations?

No. The change is **additive and dormant**:
- Sections are opt-in: a section only renders where a consuming plugin adds it to its `pages.settings` config and provides the URLs. PrestaShop/Magento are unaffected until they adopt it.
- Consumers pin a **fixed tag** (e.g. WooCommerce uses `#2.2.0`), so nobody picks this up until they bump their dependency.
- No existing enum keys, switch cases or translation keys were modified — only new ones added.

### Notes

- `dist/` is built and committed by CI (`build-and-commit-dist.yml`); not built by hand here.
- The sidebar uses the `affiliate` icon class (`sqm--affiliate`). There is **no glyph for it yet** in the icon font, so the sidebar shows the label without an icon until design adds the glyph (non-breaking).

### How is it tested?

- JS syntax validated (`node --check`) on the new/changed files; all `lang/*.json` validated as JSON.
- Functional verification happens end-to-end via the consuming plugin once `#2.4.0` is tagged and `woocommerce-sequra` #163 points at it.

### Deployment / coordination

1. Merge this PR and **tag `2.4.0`** (CI will have committed `dist/`).
2. In `woocommerce-sequra` #163, bump `sequra-core-admin-fe` to `#2.4.0`, import `AffiliateSettingsForm` in `settings.js`, and add `'affiliate'` to `pages.settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[QRD-7902]: https://sequra.atlassian.net/browse/QRD-7902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[QRD-7898]: https://sequra.atlassian.net/browse/QRD-7898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ